### PR TITLE
fixes pagination bug

### DIFF
--- a/src/pages/MyListings.tsx
+++ b/src/pages/MyListings.tsx
@@ -56,6 +56,10 @@ export default function MyListings() {
 
   if (listings) {
     totalPages = Math.ceil(listings.length / MAX_LISTINGS_PAGE);
+    const urlPage = page ? +page : 1;
+    if (urlPage > totalPages) {
+      navigate(`/mylistings/1`);
+    }
     activePageListing = arrayPagination(
       listings,
       currentPage,

--- a/src/pages/SearchResultsPage.tsx
+++ b/src/pages/SearchResultsPage.tsx
@@ -88,6 +88,11 @@ export default function SearchResultsPage() {
       1
     );
 
+    const urlPage = page ? +page : 1;
+    if (urlPage > totalPages) {
+      navigate(`/search/${searchString}/1`);
+    }
+
     if (searchListings) {
       activePageListing = arrayPagination(
         subSearchResult,
@@ -111,16 +116,16 @@ export default function SearchResultsPage() {
 
   return (
     <>
-      <main className="px-4">
+      <main className='px-4'>
         <PageHeading title={`Results for "${searchString}"`}></PageHeading>
-        <div className="flex justify-between">
-          <div className="flex items-center gap-4 mb-4" id="search-tool-bar">
+        <div className='flex justify-between'>
+          <div className='flex items-center gap-4 mb-4' id='search-tool-bar'>
             <FilterListing
               disableLocation={true}
               filterOptions={filterOptions}
               setFilterOptions={setFilterOptions}
             ></FilterListing>
-            <div className="flex gap-2 text-sm">
+            <div className='flex gap-2 text-sm'>
               <button
                 className={`px-3 py-1 ${
                   searchListings
@@ -168,7 +173,7 @@ export default function SearchResultsPage() {
           isSearchLoading ? (
             <ListingsGridSkeleton></ListingsGridSkeleton>
           ) : activePageListing.length == 0 ? (
-            <div className="h-[400px]">No listings found</div>
+            <div className='h-[400px]'>No listings found</div>
           ) : (
             <ListingsGrid ref={scrollRef}>
               {activePageListing.map((listing) => (
@@ -182,7 +187,7 @@ export default function SearchResultsPage() {
         ) : isSearchLoading ? (
           <UserListingSkeleton></UserListingSkeleton>
         ) : activeUserListings.length == 0 ? (
-          <div className="h-[400px]">No users found</div>
+          <div className='h-[400px]'>No users found</div>
         ) : (
           <UserGrid ref={scrollRef}>
             {activeUserListings.map((user) => (


### PR DESCRIPTION
users used to be able to access something like /mylistings/100 even if they didn't have 100 pages of listings which could cause pagination to bug out

if user tries this now, they are directed to page 1 of mylistings and search pages